### PR TITLE
Add Strapi integration information

### DIFF
--- a/docs/integrations/strapi.md
+++ b/docs/integrations/strapi.md
@@ -1,0 +1,7 @@
+# Strapi
+
+::: info
+This is an unofficial plugin created by the community. Unofficial plugins are not supported by us. Please open issues on GitHub if you encounter any problems.
+:::
+
+The Strapi plugin can be found on [GitHub](https://github.com/freshcodes/strapi-plugin-pirsch), kindly provided by [Fresh Codes](https://fresh.codes). Installation and usage instructions can be found in the readme file on GitHub.


### PR DESCRIPTION
We recently released a [Strapi](https://strapi.io/) [plugin](https://github.com/freshcodes/strapi-plugin-pirsch) that embeds the Pirsch dashboard into the CMS.