### PR TITLE
Astro integration

### DIFF
--- a/docs/.vitepress/config.js
+++ b/docs/.vitepress/config.js
@@ -55,6 +55,7 @@ export default {
                 text: "Integrations",
                 items: [
                     {text: "Analytics Abstraction Layer", link: "/integrations/analytics"},
+                    {text: "Astro", link: "/integrations/astro"},
                     {text: "Caddy", link: "/integrations/caddy"},
                     {text: "Docusaurus", link: "/integrations/docusaurus"},
                     {text: "FilamentPHP", link: "/integrations/filament"},

--- a/docs/advanced/proxy.md
+++ b/docs/advanced/proxy.md
@@ -33,3 +33,5 @@ The [Go server](https://github.com/pirsch-analytics/pirsch-go-proxy) is suitable
 See the readme on GitHub for details and installation instructions.
 
 You can also set up [Cloudflare Workers](https://workers.cloudflare.com/) to do the job. They are free for up to 100,000 requests per day. The instructions for the setup can be found [here](../advanced/cf-workers).
+
+There is also a [community provided integration for Astro](/integrations/astro) which acts as a proxy.

--- a/docs/integrations/astro.md
+++ b/docs/integrations/astro.md
@@ -1,0 +1,7 @@
+# Astro
+
+::: info
+This is an unofficial plugin created by the community. Unofficial plugins are not supported by us. Please open issues on GitHub if you encounter any problems.
+:::
+
+The Astro integration provides a proxy and can be found on [GitHub](https://github.com/freshcodes/astro-pirsch-proxy), kindly provided by [Fresh Codes](https://fresh.codes). Installation and usage instructions can be found in the readme file on GitHub.


### PR DESCRIPTION
I recently published an [Astro](https://astro.build) integration that sets up a proxy at https://github.com/freshcodes/astro-pirsch-proxy

I added it to the integrations list but it seemed like maybe it should be included on the proxy documentation too since it is another proxy.